### PR TITLE
Refactor config handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # set environment variables
-ENV MURMUR_VERSION=1.2.13
+ENV MURMUR_VERSION=1.2.17
 
 # Add helper files
-COPY ./apk/repositories /etc/apk/repositories
-COPY ./murmur/murmur.ini /etc/murmur/murmur.ini
+COPY ./murmur/murmur.ini ./murmur/ice.ini /etc/murmur/
 COPY ./script/docker-murmur /usr/bin/docker-murmur
 
 RUN apk --no-cache add \
@@ -13,13 +12,10 @@ RUN apk --no-cache add \
         openssl \
     && adduser -SDH murmur \
     && mkdir \
+        /data \
         /opt \
-        /var/lib/murmur \
-        /var/log/murmur \
         /var/run/murmur \
     && chown -R murmur:nobody \
-        /var/lib/murmur \
-        /var/log/murmur \
         /var/run/murmur \
         /etc/murmur \
     && wget \
@@ -34,7 +30,7 @@ EXPOSE 64738/tcp 64738/udp
 WORKDIR /etc/murmur
 
 # Add the data volume for data persistence
-VOLUME ["/etc/murmur", "/var/lib/murmur", "/var/log/murmur"]
+VOLUME ["/data/"]
 
-# Start murmur in the foreground
-ENTRYPOINT ["docker-murmur"]
+# Configure runtime container and start murmur
+ENTRYPOINT ["/usr/bin/docker-murmur"]

--- a/README.md
+++ b/README.md
@@ -76,8 +76,29 @@ docker run -d -p <HOST-PORT>:64738 --name <CONTAINER-NAME> <IMAGE-NAME>
 | CONTAINER-NAME | Desired name for the container         |
 | IMAGE-NAME     | The base image's name                  |
 
-You can additionally pass in `-e SERVER_PASSWORD='<your-password-here>'` to
-configure the murmur instance with a password.
+### Configure Container
+Each variable can be set by passing it as an environment variable (`-e`) to the server.
+
+For example: `-e MUMBLE_SERVERPASSWORD=somereallysecretpassword`.
+
+Here is a list of all options:
+
+|Variable|Setting|
+|--------|-------|
+|`MUMBLE_SERVERPASSWORD`|[serverpassword](https://wiki.mumble.info/wiki/Murmur.ini#serverpassword)|
+|`MUMBLE_DEFAULTCHANNEL`|[defaultchannel](https://wiki.mumble.info/wiki/Murmur.ini#defaultchannel)|
+|`MUMBLE_REGISTER_HOSTNAME`|[registerHostname](https://wiki.mumble.info/wiki/Murmur.ini#registerHostname)|
+|`MUMBLE_REGISTER_PASSWORD`|[registerpassword](https://wiki.mumble.info/wiki/Murmur.ini#registerPassword)|
+|`MUMBLE_REGISTER_URL`|[registerurl](https://wiki.mumble.info/wiki/Murmur.ini#registerUrl)|
+|`MUMBLE_REGISTER_NAME`|[registername](https://wiki.mumble.info/wiki/Murmur.ini#registerName)|
+|`MUMBLE_USERLIMIT`|[users](https://wiki.mumble.info/wiki/Murmur.ini#users)|
+|`MUMBLE_USERSPERCHANNEL`|[usersperchannel](https://wiki.mumble.info/wiki/Murmur.ini#usersperchannel) (disables global user limit)|
+|`MUMBLE_TEXTLENGTH`|[textmessagelength](https://wiki.mumble.info/wiki/Murmur.ini#textmessagelength)|
+|`MUMBLE_IMAGELENGTH`|[imagemessagelength](https://wiki.mumble.info/wiki/Murmur.ini#imagemessagelength)|
+|`MUMBLE_ALLOWHTML`|[allowhtml](https://wiki.mumble.info/wiki/Murmur.ini#allowhtml) (Is disabled by default and by setting the variable it'll enabled)|
+|`MUMBLE_ENABLESSL`|This is a special variable. When you set it you have to provide a key.pem and a cert.pem in your docker volume.|
+
+To customize the welcome text, add the contents to `welcome.txt` and mount that into the container at `/data/welcome.txt`. Be sure to avoid double quotes within the file!
 
 ### Logging in as SuperUser
 

--- a/apk/repositories
+++ b/apk/repositories
@@ -1,5 +1,0 @@
-http://dl-1.alpinelinux.org/alpine/v3.3/main
-http://dl-2.alpinelinux.org/alpine/v3.3/main
-http://dl-3.alpinelinux.org/alpine/v3.3/main
-http://dl-4.alpinelinux.org/alpine/v3.3/main
-http://dl-5.alpinelinux.org/alpine/v3.3/main

--- a/murmur/ice.ini
+++ b/murmur/ice.ini
@@ -1,0 +1,6 @@
+
+# ICE: LEAVE AS LAST IN FILE
+########################################
+[Ice]
+Ice.Warn.UnknownProperties=1
+Ice.MessageSizeMax=65536

--- a/murmur/murmur.ini
+++ b/murmur/murmur.ini
@@ -5,19 +5,15 @@
 
 # REQUIRED SETTINGS
 ########################################
-logdays=31
-logfile=/var/log/murmur/murmur.log
-database=/var/lib/murmur/murmur.sqlite
-dbus=session
-icesecretwrite=
+logdays=-1
+logfile=
+database=/data/murmur.sqlite
 
 # GENERAL SETTINGS
 ########################################
-welcometext="
-    <br />Welcome to this server running <b>docker-murmur</b>.
-    <br />Enjoy your stay!<br />"
 bandwidth=72000
 users=50
+#usersperchannel=
 #channelname=[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+
 #username=[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+
 #allowhtml=true
@@ -32,17 +28,17 @@ serverpassword=
 autobanAttempts = 9
 autobanTimeframe = 180
 autobanTime = 86400
-#registerName=Mumble Server
-#registerPassword=secret
-#registerUrl=http://mumble.sourceforge.net/
+#registerName=
+#registerPassword=
+#registerUrl=
 #registerHostname=
 
 # MISC SETTINGS
 ########################################
 pidfile=/var/run/murmur/murmur.pid
 uname=murmur
-#sslCert=
-#sslKey=
+#sslCert=/data/cert.pem
+#sslKey=/data/key.pem
 #certrequired=False
 
 # OTHER
@@ -59,10 +55,5 @@ uname=murmur
 #channelnestinglimit=10
 #textmessagelength=5000
 #imagemessagelength=131072
-#bonjour=False
 
-# ICE: LEAVE AS LAST IN FILE
-########################################
-[Ice]
-Ice.Warn.UnknownProperties=1
-Ice.MessageSizeMax=65536
+welcometext="<br />Welcome to this server running <b>docker-murmur</b>. <br />Enjoy your stay!<br />"

--- a/script/docker-murmur
+++ b/script/docker-murmur
@@ -1,16 +1,67 @@
 #!/bin/sh
 
-if [[ ${SERVER_PASSWORD+x} ]]; then
-    sed -i -e "s/serverpassword=/serverpassword=$SERVER_PASSWORD/" /etc/murmur/murmur.ini
+if [[ ${MUMBLE_SERVERPASSWORD+x} ]]; then
+    sed -i -e "s/serverpassword=/serverpassword=$MUMBLE_SERVERPASSWORD/" /etc/murmur/murmur.ini
 fi
 
-if [[ ! -f /opt/murmur/supwd ]]; then
+if [[ ${MUMBLE_DEFAULTCHANNEL+x} ]]; then
+    sed -i -e "s/#defaultchannel=/defaultchannel=$MUMBLE_DEFAULTCHANNEL/" /etc/murmur/murmur.ini
+fi
 
-    STORAGE_LOCATION='/opt/murmur/supwd'
+if [[ ${MUMBLE_REGISTER_HOSTNAME+x} ]]; then
+    sed -i -e "s/#registerHostname=/registerHostname=$MUMBLE_REGISTER_HOSTNAME/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_REGISTER_PASSWORD+x} ]]; then
+    sed -i -e "s/#registerPassword=/registerPassword=$MUMBLE_REGISTER_PASSWORD/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_REGISTER_URL+x} ]]; then
+    sed -i -e "s/#registerUrl=/registerUrl=$MUMBLE_REGISTER_URL/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_REGISTER_NAME+x} ]]; then
+    sed -i -e "s/#registerName=Docker-Mumble/registerName=$MUMBLE_REGISTER_NAME/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_USERLIMIT+x} ]]; then
+    sed -i -e "s/users=50/users=$MUMBLE_USERLIMIT/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_USERSPERCHANNEL+x} ]]; then
+    sed -i -e "s/#usersperchannel=/usersperchannel=$MUMBLE_USERSPERCHANNEL/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_TEXTLENGTH+x} ]]; then
+    sed -i -e "s/#textmessagelength=5000/textmessagelength=$MUMBLE_TEXTLENGTH/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_IMAGELENGTH+x} ]]; then
+    sed -i -e "s/#imagemessagelength=5000/imagemessagelength=$MUMBLE_IMAGELENGTH/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_ALLOWHTML} -eq 1 ]]; then
+    sed -i -e "s/#allowhtml/allowhtml/" /etc/murmur/murmur.ini
+fi
+
+if [[ ${MUMBLE_ENABLESSL} -eq 1 ]]; then
+    sed -i -e "s/#sslCert/sslCert/" /etc/murmur/murmur.ini
+    sed -i -e "s/#sslKey/sslKey/" /etc/murmur/murmur.ini
+fi
+
+if [[ -f /data/welcome.txt ]]; then
+    sed -i -e "s/^welcometext=.*//" /etc/murmur/murmur.ini
+    echo "welcometext=\"" >> /etc/murmur/murmur.ini
+    cat /data/welcome.txt >> /etc/murmur/murmur.ini
+    echo \" >> /etc/murmur/murmur.ini
+fi
+
+cat /etc/murmur/ice.ini >> /etc/murmur/murmur.ini
+
+chown -R murmur:nobody /data/
+
+if [[ ! -f /data/murmur.sqlite ]]; then
     SUPERUSER_PASSWORD=`pwgen -c -n -1 15`
-    echo $SUPERUSER_PASSWORD > $STORAGE_LOCATION
-    chmod 400 $STORAGE_LOCATION
-
     /opt/murmur/murmur.x86 -ini /etc/murmur/murmur.ini -supw $SUPERUSER_PASSWORD
     sleep 3
 
@@ -22,5 +73,5 @@ if [[ ! -f /opt/murmur/supwd ]]; then
     echo
 fi
 
-# start murmurd
-/opt/murmur/murmur.x86 -fg -v -ini /etc/murmur/murmur.ini
+# Run murmur
+/opt/murmur/murmur.x86 -fg -ini /etc/murmur/murmur.ini


### PR DESCRIPTION
I refactored the config handling to all needed options can be passed by environment variable.

Except certificates and the welcome message which are passed as file.

As the database is the only stateful thing it's placed in `/data`.

Why removing logs: All logging is passed to stdout and stderr. Which are handled by docker daemon. So no need to store additional logs in a volume.

Why not holding config? Config may changes in future. This removes the need to handle changed configs. Change your runtime variables and check for database migration. Everything is handle by the container.

Last but not least: disable bonjour. Bonjour is useless inside a docker container.