### PR TITLE
Enforce LF line endings, even on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Enforce LF line endings for all files, even on Windows, to avoid line ending
+# issues with the files that are added to the image when executing docker build.
+* text eol=lf

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ docker pull bddenhartog/docker-murmur
 > cd docker-murmur
 > docker build -t bddenhartog/docker-murmur .
 > ```
->
-> Windows users should run `git config --global core.autocrlf false` prior to
-> cloning to avoid line ending issues with the files that are added to the
-> image when executing `docker build`.
 
 ### Create a container
 


### PR DESCRIPTION
Fixes #35.

README.md currently suggests that Windows users modify their global Git `core.autocrlf` setting prior to cloning. This is clearly not ideal.

Issue #35 suggests asking Windows users to set `core.autocrlf=false` for this repo, upon cloning. This pull request takes another approach: it creates a `.gitattributes` file that sets `core.eol=lf` on a per-file basis.

Unlike the suggestion in #35, this does not require the user to act any differently (Windows users will use the same `git clone` command as Linux/Mac users). In addition, files created in Windows will automatically be converted from CRLF to LF.