### PR TITLE
Use LibreSSL instead of OpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:edge
 
 # Set environment variables
 ENV MURMUR_VERSION=1.2.17
@@ -9,7 +9,7 @@ COPY ./script/docker-murmur /usr/bin/docker-murmur
 
 RUN apk --no-cache add \
         pwgen \
-        openssl \
+        libressl \
     && adduser -SDH murmur \
     && mkdir \
         /data \


### PR DESCRIPTION
Closes #31.

Alpine Linux, which is used as the base image, is going to replace OpenSSL
by LibreSSL (that is already the case in their edge “branch”).
This commit makes docker-murmur also use LibreSSL, to avoid needing another
SSL stack (OpenSSL) just for it.
